### PR TITLE
Migrating Prometheus CircleCI Workflows to GitHub Actions 1/2 (CI/CD)

### DIFF
--- a/.github/workflows/scripts/install-docker.sh
+++ b/.github/workflows/scripts/install-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# DOCKER_VERSION environment variable must be set to use script
+set -x
+curl -L -o /tmp/docker-$DOCKER_VERSION.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz
+tar -xz -C /tmp -f /tmp/docker-$DOCKER_VERSION.tgz
+mv /tmp/docker/* /usr/bin

--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   pull_request:
 
+env:
+  DOCKER_VERSION: "19.03.8"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -93,12 +96,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Docker Client
-        run: |
-          set -x
-          VER="17.03.0-ce"
-          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-          mv /tmp/docker/* /usr/bin
+        run: ./.github/workflows/scripts/install-docker.sh
       - name: Sym Link Expected Path to Workspace
         run: |
           mkdir -p /go/src/github.com/prometheus/prometheus
@@ -132,15 +130,10 @@ jobs:
         run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Install Docker Client
+        run: ./.github/workflows/scripts/install-docker.sh
       - name: Setup
         run: make promu
-      - name: Install Docker Client
-        run: |
-          set -x
-          VER="17.03.0-ce"
-          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-          sudo mv /tmp/docker/* /usr/bin
       - name: Setup Remote Docker
         run: docker run --privileged linuxkit/binfmt:v0.7
       - name: Push Images to Docker # Could be made optional
@@ -175,15 +168,10 @@ jobs:
         run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Install Docker Client
+        run: ./.github/workflows/scripts/install-docker.sh
       - name: Setup
         run: make promu
-      - name: Install Docker Client
-        run: |
-          set -x
-          VER="19.03.8-ce"
-          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-          sudo mv /tmp/docker/* /usr/bin
       - name: Setup Remote Docker
         run: docker run --privileged linuxkit/binfmt:v0.7
       - run: |

--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -1,0 +1,217 @@
+name: test-build-publish
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: circleci/golang:1.15-node
+    steps:
+      - name: Permission Setup
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup
+        run: make promu
+      - run: make
+        env:
+          GOGC: "20"
+          GOOPTS: "-p 2"
+          GOMAXPROCS: "2"
+      - name: prometheus/check_proto
+        env:
+          VERSION: 3.12.3
+        run: |
+          curl -s -L https://github.com/protocolbuffers/protobuf/releases/download/v3.12.3/protoc-3.12.3-linux-x86_64.zip > /tmp/protoc.zip
+          unzip -d /tmp /tmp/protoc.zip
+          chmod +x /tmp/bin/protoc
+          echo "::add-path::/tmp/bin/"
+      - run: make proto
+      - run: git diff --exit-code
+      - name: prometheus/store_artifact prometheus
+        uses: actions/upload-artifact@v2
+        with:
+          name: prometheus
+          path: prometheus
+      - name: prometheus/store_artifact promtool
+        uses: actions/upload-artifact@v2
+        with:
+          name: promtool
+          path: promtool
+
+  test_windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: "update golang"
+        # windows-latest comes with Go 1.14.9, not Go 1.15
+        run: choco upgrade -y golang
+        shell: bash
+      - name: run tests
+        shell: bash
+        run: |
+          (cd web/ui && GOOS= GOARCH= go generate -mod=vendor)
+          go test -mod=vendor -vet=off -test.v `go list ./...|grep -Exv "(github.com/prometheus/prometheus/discovery.*|github.com/prometheus/prometheus/config|github.com/prometheus/prometheus/web)"`
+        env:
+          GOGC: "20"
+          GOOPTS: "-p 2 -mod=vendor"
+
+  test_mixins:
+    runs-on: ubuntu-latest
+    container:
+      image: circleci/golang:1.15-node
+    steps:
+      - name: Permission Setup
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - run: go install -mod=vendor ./cmd/promtool/.
+      - run: go install -mod=readonly github.com/google/go-jsonnet/cmd/jsonnet github.com/google/go-jsonnet/cmd/jsonnetfmt github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+        working-directory: documentation/prometheus-mixin
+      - run: make clean
+        working-directory: documentation/prometheus-mixin
+      - run: jb install
+        working-directory: documentation/prometheus-mixin
+      - run: make
+        working-directory: documentation/prometheus-mixin
+      - run: git diff --exit-code
+        working-directory: documentation/prometheus-mixin
+
+  fuzzit_regression:
+    runs-on: ubuntu-latest
+    container:
+      image: fuzzitdev/golang:1.12.7-buster
+    steps:
+      - name: Permission Setup
+        run: chmod -R 777 $GITHUB_WORKSPACE /github /__w/
+      - run: echo "$(GOPATH)"
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Install Docker Client
+        run: |
+          set -x
+          VER="17.03.0-ce"
+          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+          mv /tmp/docker/* /usr/bin
+      - name: Sym Link Expected Path to Workspace
+        run: |
+          mkdir -p /go/src/github.com/prometheus/prometheus
+          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/prometheus/prometheus
+      - name: Fuzzing
+        run: ./fuzzit.sh local-regression
+        working-directory: /go/src/github.com/prometheus/prometheus
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup Promu
+        run: make promu
+      - run: /home/runner/go/bin/promu crossbuild -v
+      - name: Upload .build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: .build
+          path: .build
+
+  publish_master:
+    runs-on: ubuntu-latest
+    needs: [test, build]
+    if: github.ref == 'refs/heads/master'
+    container:
+      image: circleci/golang:1-node
+    steps:
+      - name: Permission Setup
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup
+        run: make promu
+      - name: Install Docker Client
+        run: |
+          set -x
+          VER="17.03.0-ce"
+          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+          sudo mv /tmp/docker/* /usr/bin
+      - name: Setup Remote Docker
+        run: docker run --privileged linuxkit/binfmt:v0.7
+      - name: Push Images to Docker # Could be made optional
+        run: |
+          make docker DOCKER_REPO=docker.io/prom
+          docker images
+          docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD docker.io
+          make docker-publish DOCKER_REPO=docker.io/prom
+          make docker-manifest DOCKER_REPO=docker.io/prom
+        env:
+          DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      - name: Push Images to Quay # Could be made optional
+        run: |
+          make docker DOCKER_REPO=quay.io/prometheus
+          docker images
+          docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
+          make docker-publish DOCKER_REPO=quay.io/prometheus
+          make docker-manifest DOCKER_REPO=quay.io/prometheus
+        env:
+          QUAY_LOGIN: ${{ secrets.DOCKER_LOGIN }}
+          QUAY_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+
+  publish_release:
+    runs-on: ubuntu-latest
+    needs: [test, build]
+    if: "startsWith( github.ref, '.')" # Need to enforce Release Tags
+    container:
+      image: circleci/golang:1-node
+    steps:
+      - name: Permission Setup
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup
+        run: make promu
+      - name: Install Docker Client
+        run: |
+          set -x
+          VER="19.03.8-ce"
+          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+          sudo mv /tmp/docker/* /usr/bin
+      - name: Setup Remote Docker
+        run: docker run --privileged linuxkit/binfmt:v0.7
+      - run: |
+          /go/bin/promu crossbuild tarballs
+          /go/bin/promu checksum .tarballs
+          /go/bin/promu release .tarballs
+      - name: prometheus/store_artifact releases
+        uses: actions/upload-artifact@v2
+        with:
+          name: releases
+          path: .tarballs
+      - name: Push Images to Docker # Could be made optional
+        run: |
+          make docker DOCKER_REPO=docker.io/prom
+          docker images
+          docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD docker.io
+          make docker-publish DOCKER_REPO=docker.io/prom
+          make docker-manifest DOCKER_REPO=docker.io/prom
+        env:
+          DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      - name: Push Images to Quay # Could be made optional
+        run: |
+          make docker DOCKER_REPO=quay.io/prometheus
+          docker images
+          docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
+          make docker-publish DOCKER_REPO=quay.io/prometheus
+          make docker-manifest DOCKER_REPO=quay.io/prometheus
+        env:
+          QUAY_LOGIN: ${{ secrets.DOCKER_LOGIN }}
+          QUAY_PASSWORD: ${{secrets.DOCKER_PASSWORD}}


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

## What this PR does
This is part 1/2 of migrating CircleCI workflows to GitHub Actions

[**Part 1**](https://github.com/open-o11y/prometheus/pull/2) 👈 
* This PR adds the CI/CD workflow `test-build-publish` (naming convention followed from sister project [Cortex](https://github.com/open-o11y/cortex/blob/master/.github/workflows/test-build-deploy.yml))
* This PR introduces base CI jobs `test`, `test_windows`, `test_mixins`, `fuzzit_regression` and `build` which can all be run sequentially
  * CD jobs `publish_master` and `publish_release` are dependant on `build` finishing and only run on the master branch

[**Part 2**](https://github.com/open-o11y/prometheus/pull/3)
* Migrate the nightly cron jobs `repo_sync` and `fuzzit_fuzzing`
## What this PR fixes

Fixes #ISSUE NUMBER HERE