### PR TITLE
Migrating Prometheus CircleCI Workflows to GitHub Actions 2/2 (Scheduled)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,38 @@
+name: nightly
+on:
+  schedule:
+  - cron: '0 0 * * *'
+
+jobs:
+  fuzzit_fuzzing:
+    runs-on: ubuntu-latest
+    container:
+      image: fuzzitdev/golang:1.12.7-buster
+    steps:
+      - name: Setup File System Permissions
+        run: chmod -R 777 $GITHUB_WORKSPACE /github /__w/
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Sym Link Expected Path to Workspace
+        run: |
+          mkdir -p /go/src/github.com/prometheus/prometheus
+          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/prometheus/prometheus
+      - name: Fuzzing
+        run: ./fuzzit.sh fuzzing
+        env:
+          FUZZIT_API_KEY: ${{ secrets.FUZZIT_API_KEY }}
+        working-directory: /go/src/github.com/prometheus/prometheus
+  
+  repo_sync:
+    runs-on: ubuntu-latest
+    container:
+      image: circleci/golang:1.15-node
+    steps:
+      - name: Setup File System Permissions
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Sync Repository
+        run: ./scripts/sync_repo_files.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Migration of prometheus workflow that runs every night at midnight to Github Actions. Pull request upstream will only be made once informal approval is received from Prometheus community.


<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

## What this PR does
This is part 2/2 of migrating CircleCI workflows to GitHub Actions

[**Part 1**](https://github.com/open-o11y/prometheus/pull/2)
* This PR adds the CI/CD workflow `test-build-publish` (naming convention followed from sister project [Cortex](https://github.com/open-o11y/cortex/blob/master/.github/workflows/test-build-deploy.yml))
* This PR introduces base CI jobs `test`, `test_windows`, `test_mixins`, `fuzzit_regression` and `build` which can all be run sequentially
  * CD jobs `publish_master` and `publish_release` are dependant on `build` finishing and only run on the master branch

[**Part 2**](https://github.com/open-o11y/prometheus/pull/3) 👈 
* Migrate the nightly cron jobs `repo_sync` and `fuzzit_fuzzing`
## What this PR fixes

Fixes #ISSUE NUMBER HERE